### PR TITLE
ricerca posizioni senza filtri

### DIFF
--- a/src/components/Movimento/DescrizioneMov.vue
+++ b/src/components/Movimento/DescrizioneMov.vue
@@ -32,7 +32,7 @@
               :readonly="!isNewMov"></v-text-field>
           </v-flex>
           <v-flex xs6 md6 lg3 v-if="this.mostrarePosizione">
-            <v-text-field v-model="posizione" :rules="this.posizioneRules" label="Posizione"
+            <v-text-field v-model="posizione" :rules="this.posizioneRules" label="Posiz. (Attività)"
              append-icon="search" @click:append="showDialogSearchPosizione()" 
               :readonly="!isNewMov" ></v-text-field> <!-- :readonly="this.$store.getters.isNewMov ? false : true" -->
           </v-flex>
@@ -464,7 +464,8 @@ export default {
     },
     showDialogSearchPosizione() {
       if (!this.$store.getters.isNewMov) return;
-      this.posizioneSearchDialog = true;
+      //this.posizioneSearchDialog = true;
+      this.cercaPosizioneRPC(); //saltiamo i filtri
     },
     showListaCommesseDialog() {
       if (!this.$store.getters.isNewMov) return;
@@ -645,7 +646,32 @@ export default {
           this.$store.dispatch("hideWaitDialog");
           this.buono = this.buono + " !";
         });
+    },
+    cercaPosizioneRPC() {
+      this.$store.dispatch("showWaitDialog");
+      axios
+        .get("/commessa/posizioni", {
+          params: {
+            //codiceArticolo: this.codiceArticolo,
+            //descrizioneArticolo: this.descrizioneArticolo,
+            commessa: this.commessa,
+            soloPrimiLivelli: this.$store.getters.getOpzioni.soloPrimiLivelli
+          }
+        })
+        .then(res => {
+          // eslint-disable-next-line
+          console.log(res);
+          this.$store.dispatch("hideWaitDialog");
+          //this.$emit("onItemsFound", res.data);
+          this.posizioneFound(res.data);
+        })
+        .catch(error => {
+          // eslint-disable-next-line
+          console.log(error);
+          this.$store.dispatch("handleError", error.response.data);
+        });      
     }
+
   }
 };
 </script>


### PR DESCRIPTION
non si passa più atrraverso finestra intermedia per chiedere scegliere articolo/descrizione ma si cercano tutte le posizioni della commessa (o primi livelli in base a variabile)